### PR TITLE
Fixed door ownership bug

### DIFF
--- a/Harmony/Building_Door_Patch.cs
+++ b/Harmony/Building_Door_Patch.cs
@@ -19,6 +19,10 @@ namespace Locks2.Harmony
                 __result = true;
                 return false;
             }
+            if (__instance.Faction != Faction.OfPlayer && p.Faction != Faction.OfPlayer)
+            {
+                return true;
+            }
             if (p is null || p.roping is { IsRoped: true }) return true;
             var config = Finder.currentConfig = __instance.GetConfig();
             if (config is null) return true;


### PR DESCRIPTION
Fixed the door ownership bug. Enemies at map load would be unable to open their own doors, but allies would eb able to.

This patch COULD cause allies to be able to open enemies doors but I'm skeptical of that. Anyways, it fixes the more important issue of enemies not being able to open their own door. :)